### PR TITLE
Propose validation loss calculation to imporve accuracy by reducing floating-point errors

### DIFF
--- a/train_gpt2.py
+++ b/train_gpt2.py
@@ -389,8 +389,8 @@ for step in range(max_steps):
                 x, y = x.to(device), y.to(device)
                 with torch.autocast(device_type=device_type, dtype=torch.bfloat16):
                     logits, loss = model(x, y)
-                loss = loss / val_loss_steps
                 val_loss_accum += loss.detach()
+            val_loss_accum /= val_loss_steps
         if ddp:
             dist.all_reduce(val_loss_accum, op=dist.ReduceOp.AVG)
         if master_process:


### PR DESCRIPTION
Propose shift from the current approach, where loss is normalized immediately for each batch:

\$( \text{Average Loss} = \sum(\text{Normalized Losses}) \$)

to a cumulative method followed by a single normalization step:

\$( \text{Average Loss} = \frac{\text{Total Accumulated Loss}}{\text{Number of Batches}} \$) 

This aims to reduce floating-point errors and increase the accuracy of the reported validation loss.

**Changes Made** 

| Aspect             | Old Approach                                        | New Approach                                    | Reason for Change                                      |
|--------------------|-----------------------------------------------------|-------------------------------------------------|--------------------------------------------------------|
| **Calculation**    | Loss divided by number of batches before accumulating. | Accumulate all losses, then divide by batch count. | Reduces rounding errors and floating-point imprecisions. |
| **Precision**      | Potential for early precision loss due to division. | Division occurs only once, preserving precision. | Enhances the reliability of loss metrics.               |
| **Error Potential**| Higher, due to repeated operations on each batch.  | Lower, with fewer operations on critical data.  | Minimizes the accumulation of computational errors.     |