### PR TITLE
fix the double-jump for out-of-bound check in DataLoaderLite

### DIFF
--- a/train_gpt2.py
+++ b/train_gpt2.py
@@ -245,7 +245,7 @@ class DataLoaderLite:
         # advance the position in the tensor
         self.current_position += B * T * self.num_processes
         # if loading the next batch would be out of bounds, advance to next shard
-        if self.current_position + (B * T * self.num_processes + 1) > len(self.tokens):
+        if self.current_position + 1 > len(self.tokens):
             self.current_shard = (self.current_shard + 1) % len(self.shards)
             self.tokens = load_tokens(self.shards[self.current_shard])
             self.current_position = B * T * self.process_rank


### PR DESCRIPTION
`self.current_position` has already been moved at L246 and is ready for the next batch. The condition at L248 looks at yet another move, which is not correct [this way, it basically dismisses an additional block_size at the end of file]. It should simply look at currect_position + 1 to account only for the additional target token.