### PR TITLE
fix `Attempted to set non-positive bottom ylim` UserWarning in play.ipynb

### DIFF
--- a/play.ipynb
+++ b/play.ipynb
@@ -334,7 +334,7 @@
     "plt.xlabel(\"steps\")\n",
     "plt.ylabel(\"loss\")\n",
     "plt.yscale('log')\n",
-    "plt.ylim(0.0, 4.0)\n",
+    "plt.ylim(top=4.0)\n",
     "plt.legend()\n",
     "plt.title(\"Loss\")\n",
     "print(\"Min Validation Loss:\", min(ys))\n",


### PR DESCRIPTION
Note that this does not change the graph itself.

In the graph here, the 0 bottom ylim gets ignored. Let's just set the top to get rid of the warning.
https://youtu.be/l8pRSuU81PU?si=pDwdaQ1H6Qx_Of5E&t=13860
<img width="966" alt="image" src="https://github.com/karpathy/build-nanogpt/assets/19490874/ccbe8df2-9cad-4553-9210-87f4a62de397">
