### PR TITLE
fix sync issue that results in incorrect gradient accumulation and incorrect loss

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ Earlier version of PyTorch may have difficulty converting from uint16 to long. I
 
 The `torch.autocast` function takes an arg `device_type`, to which I tried to stubbornly just pass `device` hoping it works ok, but PyTorch actually really wants just the type and creates errors in some version of PyTorch. So we want e.g. the device `cuda:3` to get stripped to `cuda`. Currently, device `mps` (Apple Silicon) would become `device_type` CPU, I'm not 100% sure this is the intended PyTorch way.
 
+Confusingly, `model.require_backward_grad_sync` is actually used by both the forward and backward pass. Moved up the line so that it also gets applied to the forward pass. 
+
 ## Prod
 
 For more production-grade runs that are very similar to nanoGPT, I recommend looking at the following repos:

--- a/train_gpt2.py
+++ b/train_gpt2.py
@@ -486,6 +486,9 @@ for step in range(max_steps):
     for micro_step in range(grad_accum_steps):
         x, y = train_loader.next_batch()
         x, y = x.to(device), y.to(device)
+        # added after video, this field is also used by the forward pass.
+        if ddp:
+            model.require_backward_grad_sync = (micro_step == grad_accum_steps - 1)
         with torch.autocast(device_type=device_type, dtype=torch.bfloat16):
             logits, loss = model(x, y)
         # we have to scale the loss to account for gradient accumulation,
@@ -494,8 +497,6 @@ for step in range(max_steps):
         # instead of a SUM we want MEAN. Scale the loss here so it comes out right
         loss = loss / grad_accum_steps
         loss_accum += loss.detach()
-        if ddp:
-            model.require_backward_grad_sync = (micro_step == grad_accum_steps - 1)
         loss.backward()
     if ddp:
         dist.all_reduce(loss_accum, op=dist.ReduceOp.AVG)


### PR DESCRIPTION
## Repro
Used torch version `'2.3.1+cu121'`.
Set `B = 16` (from 64).  
The following losses were observed:
```
250 val 6.4300
250 hella 0.2440
250 train 6.387966
...
1000 val 4.8797
1000 hella 0.2419
1000 train 4.924118
...
1250 val 4.5877
1250 hella 0.2526
1250 train 4.446614
...
2500 val 4.1250
2500 hella 0.2520
2500 train 3.954155
```

This should have been a purely mechanical change that doesn't affect loss (1 -> 4 grad accum steps), but comparing to @karpathy's run, the loss is clearly worse.

## Fix
For whatever reason, both the forward and backward pass need `require_backward_grad_sync=true` set in order to sync correctly. Found this thread with a similar observation: https://discuss.pytorch.org/t/whats-no-sync-exactly-do-in-ddp/170259

## Test
Running `B=16` with the patch shows the loss we expect.
```
250 val 6.1631
250 hella 0.2434
250 train 6.128294
...
1000 val 4.1533
1000 hella 0.2602
1000 train 4.170609
...
1250 val 3.9518
1250 hella 0.2559
1250 train 3.819895
```

This should fix training on 8x NVIDIA A100 SXM 40GB :) Note that you need B=16, 32 just barely doesn't fit.
