### PR TITLE
Fix out of bounds check

### DIFF
--- a/train_gpt2.py
+++ b/train_gpt2.py
@@ -245,7 +245,7 @@ class DataLoaderLite:
         # advance the position in the tensor
         self.current_position += B * T * self.num_processes
         # if loading the next batch would be out of bounds, advance to next shard
-        if self.current_position + (B * T * self.num_processes + 1) > len(self.tokens):
+        if self.current_position + (B * T + 1) > len(self.tokens):
             self.current_shard = (self.current_shard + 1) % len(self.shards)
             self.tokens = load_tokens(self.shards[self.current_shard])
             self.current_position = B * T * self.process_rank


### PR DESCRIPTION
In DataLoader, we need to check if the next batch of data is available.
No need to multiply batch size with `num_processes`