### PR TITLE
Refactor: Replace Class Name with cls in from_pretrained Method- Fix subclassing

### DIFF
--- a/train_gpt2.py
+++ b/train_gpt2.py
@@ -145,7 +145,7 @@ class GPT(nn.Module):
         config_args['block_size'] = 1024 # always 1024 for GPT model checkpoints
         # create a from-scratch initialized minGPT model
         config = GPTConfig(**config_args)
-        model = GPT(config)
+        model = cls(config)
         sd = model.state_dict()
         sd_keys = sd.keys()
         sd_keys = [k for k in sd_keys if not k.endswith('.attn.bias')] # discard this mask / buffer, not a param


### PR DESCRIPTION
The original implementation used the class name directly to instantiate the model, which can cause issues when subclassing. This change replaces the explicit class name with cls, allowing the method to correctly instantiate instances of subclasses.

