### PR TITLE
Ensure Consistency Between GPTConfig.block_size and Sequence Length T

### DIFF
--- a/train_gpt2.py
+++ b/train_gpt2.py
@@ -321,9 +321,10 @@ if torch.cuda.is_available():
 
 enc = tiktoken.get_encoding("gpt2")
 
+model_config = GPTConfig(vocab_size=50304)
 total_batch_size = 524288 # 2**19, ~0.5M, in number of tokens
 B = 64 # micro batch size
-T = 1024 # sequence length
+T = model_config.block_size # sequence length
 assert total_batch_size % (B * T * ddp_world_size) == 0, "make sure total_batch_size is divisible by B * T * ddp_world_size"
 grad_accum_steps = total_batch_size // (B * T * ddp_world_size)
 if master_process:
@@ -336,7 +337,7 @@ val_loader = DataLoaderLite(B=B, T=T, process_rank=ddp_rank, num_processes=ddp_w
 torch.set_float32_matmul_precision('high')
 
 # create model
-model = GPT(GPTConfig(vocab_size=50304))
+model = GPT(model_config)
 # model = GPT.from_pretrained("gpt2") # or init from OpenAI GPT-2
 model.to(device)
 use_compile = False # torch.compile interferes with HellaSwag eval and Generation. TODO fix


### PR DESCRIPTION
First and foremost, I want to express my appreciation for this tutorial. It's incredibly insightful and well-structured.

I'm submitting this PR because I noticed a potential issue related to `GPTConfig.block_size` not being enforced to match the sequence length `T`.

If I understand correctly, this discrepancy could lead to unexpected model behavior during inference if `T` is lower than `GPTConfig.block_size` . (Note that an assertion error is already raised when `T` exceeds `GPTConfig.block_size`, as seen [here](https://github.com/karpathy/build-nanogpt/blob/master/train_gpt2.py#L113)).

Thank you for considering this change. Please let me know if any further adjustments are needed.