### PR TITLE
Update train_gpt2.py

### DIFF
--- a/train_gpt2.py
+++ b/train_gpt2.py
@@ -336,7 +336,7 @@ val_loader = DataLoaderLite(B=B, T=T, process_rank=ddp_rank, num_processes=ddp_w
 torch.set_float32_matmul_precision('high')
 
 # create model
-model = GPT(GPTConfig(vocab_size=50304))
+model = GPT(GPTConfig(vocab_size=50257))
 # model = GPT.from_pretrained("gpt2") # or init from OpenAI GPT-2
 model.to(device)
 use_compile = False # torch.compile interferes with HellaSwag eval and Generation. TODO fix


### PR DESCRIPTION
On line 339, the model was set up with a vocabulary size of 50304, but the GPT-2 tokenizer uses a vocabulary size of 50257. So I changed the model’s vocabulary size to 50257 to match the tokenizer.