### PR TITLE
Fix Device name when DDP is enabled

### DIFF
--- a/train_gpt2.py
+++ b/train_gpt2.py
@@ -195,7 +195,7 @@ class GPT(nn.Module):
             print(f"num non-decayed parameter tensors: {len(nodecay_params)}, with {num_nodecay_params:,} parameters")
         # Create AdamW optimizer and use the fused version if it is available
         fused_available = 'fused' in inspect.signature(torch.optim.AdamW).parameters
-        use_fused = fused_available and device_type == "cuda"
+        use_fused = fused_available and "cuda" in device_type  # makes this statement true when DDP is enabled. 
         if master_process:
             print(f"using fused AdamW: {use_fused}")
         optimizer = torch.optim.AdamW(optim_groups, lr=learning_rate, betas=(0.9, 0.95), eps=1e-8, fused=use_fused)


### PR DESCRIPTION
With DDP, device is no longer "cuda" but "cuda:"{ddp_local_rank}, which makes fused_available False.