### PR TITLE
fix data_loader shard rotation in next_batch()

### DIFF
--- a/train_gpt2.py
+++ b/train_gpt2.py
@@ -246,9 +246,9 @@ class DataLoaderLite:
         self.current_position += B * T * self.num_processes
         # if loading the next batch would be out of bounds, advance to next shard
         if self.current_position + (B * T * self.num_processes + 1) > len(self.tokens):
-            self.current_shard = (self.current_shard + 1) % len(self.shards)
+            self.current_shard = (self.current_shard + self.num_processes) % len(self.shards)
             self.tokens = load_tokens(self.shards[self.current_shard])
-            self.current_position = B * T * self.process_rank
+            self.current_position = 0
         return x, y
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
In `next_batch()`:
```python
self.current_shard = (self.current_shard + 1) % len(self.shards)
```
I think this might cause a shard repeatedly used in data-loading.
For example, with `num_processes`=4.
In the beginning, the four processes load shard 0,1,2,3, and when the shards had been completely loaded, the next shards will be 1,2,3,4 (it should be 4,5,6,7, right? emm I'm not sure whether is available to use a same data in the same epoch.)
so i think it should be
```python
self.current_shard = (self.current_shard + self.num_processes) % len(self.shards)
```

And another issue is 
```python
self.current_position = B * T * self.process_rank
```
the new shard's head doesn't be loaded(be assigned to the x,y), and the code skips it
i think it should be
```python
self.current_position = 0
```